### PR TITLE
Fix missing email_validator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ python-multipart
 python-jose
 pydantic
 pydantic-settings
+email-validator
 pytest
 httpx


### PR DESCRIPTION
## Summary
- ensure Pydantic email support by including `email-validator` in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
