### PR TITLE
Fix media directory error

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
+import os
 from .db import Base, engine
 from .routers import auth, products, orders
 
@@ -10,4 +11,6 @@ app = FastAPI(title="Freshcart Express")
 app.include_router(auth.router)
 app.include_router(products.router)
 app.include_router(orders.router)
+
+os.makedirs("media", exist_ok=True)
 app.mount("/media", StaticFiles(directory="media"), name="media")


### PR DESCRIPTION
## Summary
- create the `media` directory on startup before mounting StaticFiles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
